### PR TITLE
fix NPE

### DIFF
--- a/app/src/main/java/nl/pilight/illumina/fragment/DeviceListFragment.java
+++ b/app/src/main/java/nl/pilight/illumina/fragment/DeviceListFragment.java
@@ -113,6 +113,9 @@ public class DeviceListFragment extends BaseListFragment implements DeviceAdapte
             log.info(mLocationId + " has no devices to show");
         }
 
+        if (getActivity() == null) {
+            return;
+        }
         final DeviceAdapter adapter = new DeviceAdapter(
                 getActivity(), new ArrayList<>(location.values()), this);
 


### PR DESCRIPTION
fixes this NPE:

```
E/AndroidRuntime( 8322): java.lang.NullPointerException
E/AndroidRuntime( 8322):    at android.widget.ArrayAdapter.init(ArrayAdapter.java:314)
E/AndroidRuntime( 8322):    at android.widget.ArrayAdapter.<init>(ArrayAdapter.java:153)
E/AndroidRuntime( 8322):    at nl.pilight.illumina.widget.DeviceAdapter.<init>(DeviceAdapter.java:104)
E/AndroidRuntime( 8322):    at nl.pilight.illumina.fragment.DeviceListFragment.onLocationResponse(DeviceListFragment.java:116)
E/AndroidRuntime( 8322):    at nl.pilight.illumina.service.PilightBinder$IncomingHandler.handleMessage(PilightBinder.java:112)
E/AndroidRuntime( 8322):    at android.os.Handler.dispatchMessage(Handler.java:99)
E/AndroidRuntime( 8322):    at android.os.Looper.loop(Looper.java:132)
E/AndroidRuntime( 8322):    at android.app.ActivityThread.main(ActivityThread.java:4025)
E/AndroidRuntime( 8322):    at java.lang.reflect.Method.invokeNative(Native Method)
E/AndroidRuntime( 8322):    at java.lang.reflect.Method.invoke(Method.java:491)
E/AndroidRuntime( 8322):    at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:841)
E/AndroidRuntime( 8322):    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:599)
E/AndroidRuntime( 8322):    at dalvik.system.NativeStart.main(Native Method)
```

getActivity() might be null at this point - this fixes the crash - but it is more like a patch that might cover a underlying structural problem I have not time to investigate at the moment
